### PR TITLE
1.0.0

### DIFF
--- a/afterpay-nordics-for-woocommerce.php
+++ b/afterpay-nordics-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Plugin Name:     AfterPay Nordics for WooCommerce
  * Plugin URI:      https://krokedil.se/afterpay/
  * Description:     Provides an AfterPay v3 payment gateway for WooCommerce.
- * Version:         0.9.0
+ * Version:         1.0.0
  * Author:          Krokedil
  * Author URI:      https://krokedil.se/
  * Developer:       Krokedil
@@ -18,10 +18,10 @@
  * Text Domain:     afterpay-nordics-for-woocommerce
  * Domain Path:     /languages
  *
- * WC requires at least: 3.2.0
- * WC tested up to: 3.8.1
+ * WC requires at least: 4.0.0
+ * WC tested up to: 5.0.0
  *
- * Copyright:       © 2017-2020 Krokedil.
+ * Copyright:       © 2017-2021 Krokedil.
  * License:         GNU General Public License v3.0
  * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -39,7 +39,7 @@ load_plugin_textdomain( 'afterpay-nordics-for-woocommerce', false, dirname( plug
 // Define plugin paths
 define( 'AFTERPAY_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'AFTERPAY_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
-define( 'AFTERPAY_VERSION', '0.9.0' );
+define( 'AFTERPAY_VERSION', '1.0.0' );
 
 // Compatibility functions
 require_once AFTERPAY_PATH . '/includes/krokedil-compatibility-functions.php';

--- a/assets/js/pre-check-customer.js
+++ b/assets/js/pre-check-customer.js
@@ -60,6 +60,9 @@ jQuery(function ($) {
 				jQuery('.afterpay-pre-check-se').fadeOut();
 				jQuery('.afterpay-pre-check-no').fadeOut();
 				jQuery( '.personal-number-norway' ).hide();
+			} else if ( selected_customer_country == 'DK' ) {
+				jQuery('.afterpay-pre-check-se').fadeOut();
+				jQuery('.afterpay-pre-check-no').fadeOut();
 			} else {
 				jQuery( '.afterpay-pre-check-no' ).fadeIn();
 				jQuery( '.afterpay-pre-check-se' ).fadeOut();

--- a/includes/class-process-order-lines.php
+++ b/includes/class-process-order-lines.php
@@ -42,7 +42,7 @@ class WC_AfterPay_Process_Order_Lines {
 		// Process order lines
 		if ( sizeof( $order->get_items() ) > 0 ) {
 			foreach ( $order->get_items() as $item_key => $item ) {
-				$_product = $order->get_product_from_item( $item );
+				$_product = $item->get_product();
 				if ( 0 == $order->get_line_tax( $item ) ) {
 					$vat = $order->get_line_tax( $item );
 				} else {

--- a/includes/gateways/class-wc-gateway-afterpay-factory.php
+++ b/includes/gateways/class-wc-gateway-afterpay-factory.php
@@ -155,6 +155,25 @@ function init_wc_gateway_afterpay_factory_class() {
 					),
 					'default' => 'yes',
 				),
+				'section_denmark'        => array(
+					'title' => __( 'Denmark', 'afterpay-nordics-for-woocommerce' ),
+					'type'  => 'title',
+				),
+				'x_auth_key_dk'          => array(
+					'title'       => __( 'AfterPay X-Auth-Key Denmark', 'afterpay-nordics-for-woocommerce' ),
+					'type'        => 'text',
+					'description' => __(
+						'Please enter your AfterPay X-Auth-Key for Denmark; this is needed in order to take payment',
+						'afterpay-nordics-for-woocommerce'
+					),
+				),
+				'description_dk'         => array(
+					'title'       => __( 'Description Denmark', 'afterpay-nordics-for-woocommerce' ),
+					'type'        => 'textarea',
+					'desc_tip'    => true,
+					'description' => __( 'This controls the description which Danish customers sees during checkout.', 'afterpay-nordics-for-woocommerce' ),
+					'default'     => $this->get_default_description_denmark(),
+				),
 			);
 			// Only invoice payments for DE.
 			if ( 'afterpay_invoice' === $this->id ) {
@@ -294,7 +313,7 @@ function init_wc_gateway_afterpay_factory_class() {
 			// @Todo - check if this is needed (for Norway) since we don't do Available payment methods there
 			$customer_number_norway = $this->id . '-check-customer-number-norway';
 
-			if ( isset( $_POST[ $customer_number_norway ] ) && 'NO' == $_POST['billing_country'] ) {
+			if ( isset( $_POST[ $customer_number_norway ] ) && in_array( $_POST['billing_country'], array( 'NO', 'DK' ), true ) ) {
 				$personal_number = wc_clean( $_POST[ $customer_number_norway ] );
 				$personal_number = str_replace( '-', '', $personal_number );
 				WC()->session->set( 'afterpay_personal_no', $personal_number );
@@ -474,6 +493,9 @@ function init_wc_gateway_afterpay_factory_class() {
 				case 'NOK':
 					$description = $this->description_no;
 					break;
+				case 'DKK':
+					$description = $this->description_dk;
+					break;
 				case 'EUR':
 					$description = $this->description_de;
 					break;
@@ -523,54 +545,54 @@ function init_wc_gateway_afterpay_factory_class() {
 			$customer_category = get_post_meta( $order_id, '_afterpay_customer_category', true );
 			$changed_fields    = array();
 
-			$billing_first_name = sanitize_text_field( $response->customer->firstName );
-			$billing_last_name  = sanitize_text_field( $response->customer->lastName );
-			$billing_address    = sanitize_text_field( $response->customer->addressList[0]->street );
-			$billing_postcode   = sanitize_text_field( $response->customer->addressList[0]->postalCode );
-			$billing_city       = sanitize_text_field( $response->customer->addressList[0]->postalPlace );
+			$billing_first_name = isset( $response->customer->firstName ) ? sanitize_text_field( $response->customer->firstName ) : '';
+			$billing_last_name  = isset( $response->customer->lastName ) ? sanitize_text_field( $response->customer->lastName ) : '';
+			$billing_address    = isset( $response->customer->addressList[0]->street ) ? sanitize_text_field( $response->customer->addressList[0]->street ) : '';
+			$billing_postcode   = isset( $response->customer->addressList[0]->postalCode ) ? sanitize_text_field( $response->customer->addressList[0]->postalCode ) : '';
+			$billing_city       = isset( $response->customer->addressList[0]->postalPlace ) ? sanitize_text_field( $response->customer->addressList[0]->postalPlace ) : '';
 
 			// Shipping address.
-			if ( ! empty( $billing_address ) && mb_strtoupper( $billing_address ) != mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_address_1' ) ) ) {
+			if ( ! empty( $billing_address ) && mb_strtoupper( $billing_address ) !== mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_address_1' ) ) ) {
 				$changed_fields['billing_address_1'] = $billing_address . ' (' . krokedil_get_order_property( $order_id, 'billing_address_1' ) . ')';
-				update_post_meta( $order->id, '_shipping_address_1', $billing_address );
-				update_post_meta( $order->id, '_billing_address_1', $billing_address );
+				update_post_meta( $order_id, '_shipping_address_1', $billing_address );
+				update_post_meta( $order_id, '_billing_address_1', $billing_address );
 			}
 			// Post number.
-			if ( ! empty( $billing_postcode ) && mb_strtoupper( $billing_postcode ) != mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_postcode' ) ) ) {
+			if ( ! empty( $billing_postcode ) && mb_strtoupper( $billing_postcode ) !== mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_postcode' ) ) ) {
 				$changed_fields['billing_postcode'] = $billing_postcode . ' (' . krokedil_get_order_property( $order_id, 'billing_postcode' ) . ')';
-				update_post_meta( $order->id, '_shipping_postcode', $billing_postcode );
-				update_post_meta( $order->id, '_billing_postcode', $billing_postcode );
+				update_post_meta( $order_id, '_shipping_postcode', $billing_postcode );
+				update_post_meta( $order_id, '_billing_postcode', $billing_postcode );
 			}
 			// City.
-			if ( ! empty( $billing_city ) && mb_strtoupper( $billing_city ) != mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_city' ) ) ) {
+			if ( ! empty( $billing_city ) && mb_strtoupper( $billing_city ) !== mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_city' ) ) ) {
 				$changed_fields['billing_city'] = $billing_city . ' (' . $order->get_billing_city() . ')';
-				update_post_meta( $order->id, '_shipping_city', $billing_city );
-				update_post_meta( $order->id, '_billing_city', $billing_city );
+				update_post_meta( $order_id, '_shipping_city', $billing_city );
+				update_post_meta( $order_id, '_billing_city', $billing_city );
 			}
 
-			// Person check
-			if ( 'Person' == $customer_category ) {
+			// Person check.
+			if ( 'Person' === $customer_category ) {
 				// First name.
-				if ( ! empty( $billing_first_name ) && mb_strtoupper( $billing_first_name ) != mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_first_name' ) ) ) {
+				if ( ! empty( $billing_first_name ) && mb_strtoupper( $billing_first_name ) !== mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_first_name' ) ) ) {
 					$changed_fields['billing_first_name'] = $billing_first_name . ' (' . krokedil_get_order_property( $order_id, 'billing_first_name' ) . ')';
-					update_post_meta( $order->id, '_shipping_first_name', $billing_first_name );
-					update_post_meta( $order->id, '_billing_first_name', $billing_first_name );
+					update_post_meta( $order_id, '_shipping_first_name', $billing_first_name );
+					update_post_meta( $order_id, '_billing_first_name', $billing_first_name );
 				}
 				// Last name.
-				if ( ! empty( $billing_last_name ) && mb_strtoupper( $billing_last_name ) != mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_last_name' ) ) ) {
+				if ( ! empty( $billing_last_name ) && mb_strtoupper( $billing_last_name ) !== mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_last_name' ) ) ) {
 					$changed_fields['billing_last_name'] = $billing_last_name . ' (' . krokedil_get_order_property( $order_id, 'billing_last_name' ) . ')';
-					update_post_meta( $order->id, '_shipping_last_name', $billing_last_name );
-					update_post_meta( $order->id, '_billing_last_name', $billing_last_name );
+					update_post_meta( $order_id, '_shipping_last_name', $billing_last_name );
+					update_post_meta( $order_id, '_billing_last_name', $billing_last_name );
 				}
 			}
 
-			// Company check
-			if ( 'Company' == $customer_category ) {
+			// Company check.
+			if ( 'Company' === $customer_category ) {
 				// Company name.
-				if ( ! empty( $billing_last_name ) && mb_strtoupper( $billing_last_name ) != mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_company' ) ) ) {
+				if ( ! empty( $billing_last_name ) && mb_strtoupper( $billing_last_name ) !== mb_strtoupper( krokedil_get_order_property( $order_id, 'billing_company' ) ) ) {
 					$changed_fields['billing_company'] = $billing_last_name . ' (' . krokedil_get_order_property( $order_id, 'billing_company' ) . ')';
-					update_post_meta( $order->id, '_billing_company', $billing_last_name );
-					update_post_meta( $order->id, '_shipping_company', $billing_last_name );
+					update_post_meta( $order_id, '_billing_company', $billing_last_name );
+					update_post_meta( $order_id, '_shipping_company', $billing_last_name );
 				}
 			}
 
@@ -670,6 +692,11 @@ function init_wc_gateway_afterpay_factory_class() {
 					$short_readmore = 'Les mer her';
 					$afterpay_info .= '<a target="_blank" href="https://www.afterpay.no/nb/vilkar">' . $short_readmore . '</a>';
 					break;
+				case 'DKK':
+					$afterpay_info  = '<p class="afterpay-credit-check-info"><small>Ved bruk av denne tjenesten gjøres en kredittsjekk. Gjenpartsbrev sendes fortrinnsvis elektronisk. Varene sendes kun till folkeregistret adresse.</small></p>';
+					$short_readmore = 'Les mer her';
+					$afterpay_info .= '<a target="_blank" href="https://www.afterpay.dk/da/vilkaar-og-betingelser">' . $short_readmore . '</a>';
+					break;
 				case 'SEK':
 					$terms_url      = 'https://documents.myafterpay.com/consumer-terms-conditions/sv_se/';
 					$afterpay_info .= '<p class="afterpay-terms-link"><a href="' . $terms_url . '" target="_blank">' . __( 'Read AfterPay Terms & Conditions', 'afterpay-nordics-for-woocommerce' ) . '</a>.</p>';
@@ -744,6 +771,29 @@ function init_wc_gateway_afterpay_factory_class() {
 					break;
 				case 'afterpay_part_payment':
 					$description = '• Samma belopp varje månad<br> •Du kan även betala det totala beloppet när du vill';
+					break;
+				default:
+					$description = '';
+			}
+
+			return $description;
+		}
+
+		/**
+		 * Denmark function.
+		 *
+		 * @return string
+		 */
+		public function get_default_description_denmark() {
+			switch ( $this->id ) {
+				case 'afterpay_invoice':
+					$description = 'Betal varene om 14 dager.';
+					break;
+				case 'afterpay_account':
+					$description = '<h4>Detaljer:</h4>Månedspris: <strong>Minimum kr 100 eller ca 12% av totalbeløpet</strong><br>Etableringsgebyr: <strong>0 Kr</strong><br>Rente: <strong>19.95%</strong></p><p><small>Ved et kjøp på 5000 DKK der netbetalingen foregår over 1 år, der betalingen har et fakturagebyr på 39 DKK med en rente på 19.95% vil du få en årlig sammenlignbar rente på 45,18%. Den totale kredittkjøpsprisen vil være 6084 DKK.</small></p>';
+					break;
+				case 'afterpay_part_payment':
+					$description = 'Del opp betalingen i faste avdrag.';
 					break;
 				default:
 					$description = '';
@@ -838,8 +888,8 @@ function init_wc_gateway_afterpay_factory_class() {
 				return false;
 			}
 
-			// Check order currency to be able to send correct x_auth_key
-			$currency = krokedil_get_order_property( $order_id, 'order_currency' );
+			// Check order currency to be able to send correct x_auth_key.
+			$currency = $order->get_currency();
 			switch ( $currency ) {
 				case 'NOK':
 					$this->x_auth_key = $this->x_auth_key_no;

--- a/includes/gateways/class-wc-gateway-afterpay-invoice.php
+++ b/includes/gateways/class-wc-gateway-afterpay-invoice.php
@@ -39,6 +39,7 @@ function init_wc_gateway_afterpay_invoice_class() {
 			$this->description_se = $this->get_option( 'description_se' );
 			$this->description_no = $this->get_option( 'description_no' );
 			$this->description_de = $this->get_option( 'description_de' );
+			$this->description_dk = $this->get_option( 'description_dk' );
 			$this->debug          = $this->get_option( 'debug' );
 			$this->client_id_se   = $this->get_option( 'client_id_se' );
 			$this->username_se    = $this->get_option( 'username_se' );
@@ -52,6 +53,7 @@ function init_wc_gateway_afterpay_invoice_class() {
 			$this->x_auth_key_se  = $this->get_option( 'x_auth_key_se' );
 			$this->x_auth_key_no  = $this->get_option( 'x_auth_key_no' );
 			$this->x_auth_key_de  = $this->get_option( 'x_auth_key_de' );
+			$this->x_auth_key_dk  = $this->get_option( 'x_auth_key_dk' );
 			$this->testmode       = $this->get_option( 'testmode' );
 
 			// Invoice fee
@@ -74,6 +76,10 @@ function init_wc_gateway_afterpay_invoice_class() {
 					$this->username         = $this->username_se;
 					$this->password         = $this->password_se;
 					$this->x_auth_key       = $this->x_auth_key_se;
+					break;
+				case 'DKK':
+					$this->afterpay_country = 'DK';
+					$this->x_auth_key       = $this->x_auth_key_dk;
 					break;
 				case 'EUR':
 					$this->afterpay_country = 'DE';

--- a/includes/gateways/class-wc-gateway-afterpay-part-payment.php
+++ b/includes/gateways/class-wc-gateway-afterpay-part-payment.php
@@ -29,76 +29,85 @@ function init_wc_gateway_afterpay_part_payment_class() {
 		 * Constructor for the gateway.
 		 */
 		public function __construct() {
-			$this->id                 = 'afterpay_part_payment';
-			$this->method_title       = __( 'AfterPay Part Payment', 'afterpay-nordics-for-woocommerce' );
+			$this->id           = 'afterpay_part_payment';
+			$this->method_title = __( 'AfterPay Part Payment', 'afterpay-nordics-for-woocommerce' );
 
-			//$this->icon               = apply_filters( 'woocommerce_afterpay_part_payment_icon', AFTERPAY_URL . '/assets/images/logo.png' );
+			// $this->icon               = apply_filters( 'woocommerce_afterpay_part_payment_icon', AFTERPAY_URL . '/assets/images/logo.png' );
 			$this->has_fields         = true;
 			$this->method_description = __( 'Allows payments through ' . $this->method_title . '.', 'afterpay-nordics-for-woocommerce' );
 
 			// Define user set variables
-			$this->title       			= $this->get_option( 'title' );
-			$this->description_se 		= $this->get_option( 'description_se' );
-			$this->description_no 		= $this->get_option( 'description_no' );
-			$this->client_id_se   		= $this->get_option( 'client_id_se' );
-			$this->username_se    		= $this->get_option( 'username_se' );
-			$this->password_se    		= $this->get_option( 'password_se' );
-			$this->client_id_no   		= $this->get_option( 'client_id_no' );
-			$this->username_no    		= $this->get_option( 'username_no' );
-			$this->password_no    		= $this->get_option( 'password_no' );
-			$this->debug       			= $this->get_option( 'debug' );
-			$this->api_key       		= $this->get_option( 'api_key' );
-			$this->x_auth_key_se    	= $this->get_option( 'x_auth_key_se' );
-			$this->x_auth_key_no    	= $this->get_option( 'x_auth_key_no' );
-			$this->account_profile_no	= $this->get_option( 'account_profile_no' );
-			$this->testmode       		= $this->get_option( 'testmode' );
+			$this->title              = $this->get_option( 'title' );
+			$this->description_se     = $this->get_option( 'description_se' );
+			$this->description_no     = $this->get_option( 'description_no' );
+			$this->client_id_se       = $this->get_option( 'client_id_se' );
+			$this->username_se        = $this->get_option( 'username_se' );
+			$this->password_se        = $this->get_option( 'password_se' );
+			$this->client_id_no       = $this->get_option( 'client_id_no' );
+			$this->username_no        = $this->get_option( 'username_no' );
+			$this->password_no        = $this->get_option( 'password_no' );
+			$this->debug              = $this->get_option( 'debug' );
+			$this->api_key            = $this->get_option( 'api_key' );
+			$this->x_auth_key_se      = $this->get_option( 'x_auth_key_se' );
+			$this->x_auth_key_no      = $this->get_option( 'x_auth_key_no' );
+			$this->account_profile_no = $this->get_option( 'account_profile_no' );
+			$this->testmode           = $this->get_option( 'testmode' );
 
 			// Set country and merchant credentials based on currency.
 			switch ( get_woocommerce_currency() ) {
-				case 'NOK' :
-					$this->afterpay_country 	= 'NO';
-					$this->client_id  			= $this->client_id_no;
-					$this->username     		= $this->username_no;
-					$this->password     		= $this->password_no;
-					$this->x_auth_key			= $this->x_auth_key_no;
+				case 'NOK':
+					$this->afterpay_country = 'NO';
+					$this->client_id        = $this->client_id_no;
+					$this->username         = $this->username_no;
+					$this->password         = $this->password_no;
+					$this->x_auth_key       = $this->x_auth_key_no;
 					break;
-				case 'SEK' :
-					$this->afterpay_country		= 'SE';
-					$this->client_id  			= $this->client_id_se;
-					$this->username     		= $this->username_se;
-					$this->password     		= $this->password_se;
-					$this->x_auth_key			= $this->x_auth_key_se;
+				case 'SEK':
+					$this->afterpay_country = 'SE';
+					$this->client_id        = $this->client_id_se;
+					$this->username         = $this->username_se;
+					$this->password         = $this->password_se;
+					$this->x_auth_key       = $this->x_auth_key_se;
 					break;
 				default:
-					$this->afterpay_country 	= '';
-					$this->client_id  			= '';
-					$this->username     		= '';
-					$this->password     		= '';
-					$this->x_auth_key			= '';
+					$this->afterpay_country = '';
+					$this->client_id        = '';
+					$this->username         = '';
+					$this->password         = '';
+					$this->x_auth_key       = '';
 			}
-			
+
 			// Load the settings.
 			$this->init_form_fields();
 			$this->init_settings();
 
 			$this->supports = array(
 				'products',
-				'refunds'
+				'refunds',
 			);
 
 			// Actions
-			add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array(
-				$this,
-				'process_admin_options'
-			) );
-			add_action( 'woocommerce_thankyou', array( 
-				$this, 
-				'clear_afterpay_sessions' 
-			) );
-			add_action( 'woocommerce_checkout_process', array( 
-				$this, 
-				'process_checkout_fields' 
-			) );
+			add_action(
+				'woocommerce_update_options_payment_gateways_' . $this->id,
+				array(
+					$this,
+					'process_admin_options',
+				)
+			);
+			add_action(
+				'woocommerce_thankyou',
+				array(
+					$this,
+					'clear_afterpay_sessions',
+				)
+			);
+			add_action(
+				'woocommerce_checkout_process',
+				array(
+					$this,
+					'process_checkout_fields',
+				)
+			);
 		}
 
 		/**
@@ -106,12 +115,12 @@ function init_wc_gateway_afterpay_part_payment_class() {
 		 */
 		public function payment_fields() {
 			parent::payment_fields();
-			
+
 			// Print AfterPay Terms & Conditions link
 			echo $this->get_afterpay_info();
-			
+
 			$this->get_available_installment_plans();
-			
+
 		}
 
 		/**
@@ -125,46 +134,46 @@ function init_wc_gateway_afterpay_part_payment_class() {
 		public function sort_payment_plans( $plana, $planb ) {
 			return $plana->NumberOfInstallments > $planb->NumberOfInstallments;
 		}
-		
+
 		/**
 		 * Get available installment plans
-		 *
 		 */
-		public function get_available_installment_plans( ) {
+		public function get_available_installment_plans() {
 			switch ( get_woocommerce_currency() ) {
-				case 'SEK' :
+				case 'SEK':
 					$country_code = 'SE';
 					break;
-				case 'NOK' :
+				case 'NOK':
 					$country_code = 'NO';
 					break;
-				default :
+				default:
 					$country_code = 'SE';
 			}
-			
-			$request  = new WC_AfterPay_Request_Available_Installment_Plans( $this->x_auth_key, $this->testmode );
-			$response = $request->response( WC()->cart->total, get_woocommerce_currency(), $country_code );
-			$response  = json_decode( $response );
+
+			$request                        = new WC_AfterPay_Request_Available_Installment_Plans( $this->x_auth_key, $this->testmode );
+			$response                       = $request->response( WC()->cart->total, get_woocommerce_currency(), $country_code );
+			$response                       = json_decode( $response );
+			$payment_options_details_output = '';
 			/*
 			echo '<pre>';
 			print_r( $response );
 			echo '</pre>';
 			*/
-			
+
 			if ( ! is_wp_error( $response ) ) {
-				if( is_array( $response ) && 'BusinessError' == $response[0]->type) {
+				if ( is_array( $response ) && 'BusinessError' == $response[0]->type ) {
 					echo '<p>' . $response[0]->message . '</p>';
 				} else {
 					$installment_plans = $response->availableInstallmentPlans;
-					if( $installment_plans ) {
-					
-						//WC()->session->set( 'afterpay_available_installment_plans', $response->availableInstallmentPlans );
-					   
+					if ( $installment_plans ) {
+
+						// WC()->session->set( 'afterpay_available_installment_plans', $response->availableInstallmentPlans );
+
 						echo '<p>' . __( 'Please select a payment plan:', 'afterpay-nordics-for-woocommerce' ) . '</p>';
 						$i = 0;
-						foreach( $installment_plans as $key => $installment_plan ) {
-							
-							if( $installment_plan->installmentProfileNumber < 11 ) {
+						foreach ( $installment_plans as $key => $installment_plan ) {
+
+							if ( $installment_plan->installmentProfileNumber < 11 ) {
 								$i ++;
 								$label = sprintf(
 									'%1$s %2$s, %3$s / %4$s',
@@ -173,8 +182,7 @@ function init_wc_gateway_afterpay_part_payment_class() {
 									wc_price( round( $installment_plan->installmentAmount ) ),
 									__( 'mo', 'afterpay-nordics-for-woocommerce' )
 								);
-		
-		
+
 								// Create payment plan details output
 								if ( $i < 2 ) {
 									$inline_style = 'style="clear:both;position:relative"';
@@ -183,34 +191,34 @@ function init_wc_gateway_afterpay_part_payment_class() {
 									$inline_style = 'style="clear:both;display:none;position:relative"';
 									$extra_class  = '';
 								}
-								
+
 								$payment_options_details_output .= '<div class="afterpay-ppp-details ' . $extra_class . '" data-campaign="' . $installment_plan->installmentProfileNumber . '" ' . $inline_style . '><small>';
-								
-								$payment_options_details_output .= sprintf( __( 'Start fee: %1$s. Monthly fee: %2$s. Rate: %3$s%5$s. Annual effective rate: %4$s%5$s. Total: %6$s.', 'afterpay-nordics-for-woocommerce' ),
-								wc_price($installment_plan->startupFee),
-								wc_price($installment_plan->monthlyFee),
-								$installment_plan->interestRate,
-								$installment_plan->effectiveAnnualPercentageRate, 
-								'%', 
-								wc_price($installment_plan->totalAmount) );
+
+								$payment_options_details_output .= sprintf(
+									__( 'Start fee: %1$s. Monthly fee: %2$s. Rate: %3$s%5$s. Annual effective rate: %4$s%5$s. Total: %6$s.', 'afterpay-nordics-for-woocommerce' ),
+									wc_price( $installment_plan->startupFee ),
+									wc_price( $installment_plan->monthlyFee ),
+									$installment_plan->interestRate,
+									$installment_plan->effectiveAnnualPercentageRate,
+									'%',
+									wc_price( $installment_plan->totalAmount )
+								);
 								$payment_options_details_output .= '</small></div>';
-		
+
 								echo '<input type="radio" name="afterpay_installment_plan" id="afterpay-installment-plan-' . $installment_plan->installmentProfileNumber . '" value="' . $installment_plan->installmentProfileNumber . '" ' . checked( $key, 0, false ) . ' />';
 								echo '<label for="afterpay-installment-plan-' . $installment_plan->installmentProfileNumber . '"> ' . $label . '</label>';
-								echo '<br>';	
+								echo '<br>';
 							}
 						}
 
-						// Print payment plan details					
+						// Print payment plan details
 						echo $payment_options_details_output;
-						
+
 					}
 				}
-				
-	
 			} else {
-				//WC()->session->__unset( 'afterpay_installment_plans' );
-				
+				// WC()->session->__unset( 'afterpay_installment_plans' );
+
 			}
 		}
 	}

--- a/includes/requests/helpers/class-wc-afterpay-request-authorize-payment.php
+++ b/includes/requests/helpers/class-wc-afterpay-request-authorize-payment.php
@@ -59,7 +59,7 @@ class WC_AfterPay_Request_Authorize_Payment extends WC_AfterPay_Request {
 	private function get_request_body( $order_id, $payment_method_name, $profile_no = false ) {
 		$order = wc_get_order( $order_id );
 
-		// Prepare order lines for AfterPay
+		// Prepare order lines for AfterPay.
 		$order_lines_processor = new WC_AfterPay_Process_Order_Lines();
 		$order_lines           = $order_lines_processor->get_order_lines( $order_id );
 		$net_total_amount      = 0;
@@ -88,7 +88,7 @@ class WC_AfterPay_Request_Authorize_Payment extends WC_AfterPay_Request {
 				'number'           => $order->get_order_number(),
 				'totalGrossAmount' => round( $order->get_total(), 2 ),
 				'TotalNetAmount'   => round( $net_total_amount, 2 ),
-				'currency'         => krokedil_get_order_property( $order_id, 'order_currency' ),
+				'currency'         => $order->get_currency(),
 				'items'            => $order_lines,
 			),
 		);

--- a/includes/requests/helpers/class-wc-afterpay-request-capture-payment.php
+++ b/includes/requests/helpers/class-wc-afterpay-request-capture-payment.php
@@ -15,11 +15,11 @@ class WC_AfterPay_Request_Capture_Payment extends WC_AfterPay_Request {
 	private $request_method = 'POST';
 
 	public function response( $order_id ) {
-		$wc_order = wc_get_order( $order_id );
+		$wc_order     = wc_get_order( $order_id );
 		$order_number = $wc_order->get_order_number();
-		$request_url = $this->base_url . '/api/v3/orders/' . $order_number . '/captures';
+		$request_url  = $this->base_url . '/api/v3/orders/' . $order_number . '/captures';
 		WC_Gateway_AfterPay_Factory::log( 'Capture payment request sent to: ' . $request_url );
-		$request     = wp_remote_retrieve_body( wp_remote_request( $request_url, $this->get_request_args( $order_id ) ) );
+		$request = wp_remote_retrieve_body( wp_remote_request( $request_url, $this->get_request_args( $order_id ) ) );
 		WC_Gateway_AfterPay_Factory::log( 'Capture payment response: ' . var_export( $request, true ) );
 		return $request;
 	}
@@ -34,19 +34,27 @@ class WC_AfterPay_Request_Capture_Payment extends WC_AfterPay_Request {
 	}
 
 	private function get_request_body( $order_id ) {
-		$order = wc_get_order( $order_id );
+		$order                  = wc_get_order( $order_id );
+		$order_total_net_amount = $order->get_total() - $order->get_total_tax();
+
+		// Prepare order lines for AfterPay
+		$order_lines_processor = new WC_AfterPay_Process_Order_Lines();
+		$order_lines           = $order_lines_processor->get_order_lines( $order_id );
+
 		$request_body = array(
 			'orderDetails' => array(
-				'totalGrossAmount' => $order->get_total(),
-				'currency' => krokedil_get_order_property( $order_id, 'order_currency' ),
+				'totalGrossAmount' => round( $order->get_total(), 2 ),
+				'totalNetAmount'   => round( $order_total_net_amount, 2 ),
+				'currency'         => $order->get_currency(),
+				'items'            => $order_lines,
 			),
 		);
 
 		// Add reference if this is a B2B purchase (first and last name is not sent in authorize request).
 		$customer_category = get_post_meta( $order_id, '_afterpay_customer_category', true );
-		if( 'Company' == $customer_category ) {
+		if ( 'Company' == $customer_category ) {
 			$request_body['references'] = array(
-				'yourReference' => substr( krokedil_get_order_property( $order_id, 'billing_first_name' ) . ' ' . krokedil_get_order_property( $order_id, 'billing_last_name' ), 0, 19),
+				'yourReference' => substr( krokedil_get_order_property( $order_id, 'billing_first_name' ) . ' ' . krokedil_get_order_property( $order_id, 'billing_last_name' ), 0, 19 ),
 			);
 		}
 		return wp_json_encode( $request_body );

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,10 @@
 Contributors: krokedil, arvato, NiklasHogefjord, slobodanmanic
 Tags: ecommerce, e-commerce, woocommerce, afterpay, arvato
 Requires at least: 4.2
-Tested up to: 5.5
+Tested up to: 5.6.1
 Requires PHP: 5.6
-WC requires at least: 3.2.0
-WC tested up to: 4.4.1
-Stable tag: trunk
+WC requires at least: 4.0.0
+WC tested up to: 5.0.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -40,56 +39,63 @@ If you get stuck, you can send a support ticket to support@krokedil.se. You can 
 
 
 == Changelog ==
-= 2020.01.14 		- version 0.9.0 =
+= 2021.02.17    - 1.0.0 =
+* Feature       - Adds support for invoice payments for Danish customers.
+* Tweak         - Adds totalNetAmount & order lines to capture payment request.
+* Tweak         - Adds netUnitPrice & vatAmount to refund payment requests.
+* Fix           - WC deprecated notices & PHP notices fix.
+* Fix           - Do not overwrite the customer address in Woo order if company address isn't returned at all from AfterPay.
+
+= 2020.01.14    - 0.9.0 =
 * Feature       - Add setting for display/hide Get Address field in checkout for Norwegian customers.
 * Feature       - Add setting for wether or not to display Get address field if AfterPay isn't the selected payment method.
 * Tweak         - Send vatAmount in requests to AfterPay.
 
-= 2019.06.07 		- version 0.8.5 =
+= 2019.06.07 	- version 0.8.5 =
 * Fix           - Don't check and correct billing address in Woo order for DE customers. This is handled by AfterPay before order is approved in checkout.
 
-= 2019.06.05 		- version 0.8.4 =
+= 2019.06.05 	- version 0.8.4 =
 * Fix           - Add response code 200.104 (Address Correction) during Authorize request response as valid response to adjust WooCommerce checkout address.
 * Fix           - Fixed customer last name not being set correctly during address adjustement for DE customers.
 
-= 2019.06.04 		- version 0.8.3 =
+= 2019.06.04 	- version 0.8.3 =
 * Feature       - Added setting for allowing Street number to be a separate field in WooCommerce checkout. That input field will be sent as streetNumber to AfterPay. 
 * Tweak         - Improved handling of Street number, Additional street number & Care of returned from AfterPay. Mainly for DE customers.
 
-= 2019.05.28 		- version 0.8.2 =
+= 2019.05.28 	- version 0.8.2 =
 * Fix           - Don't send mobilePhone param to AfterPay if billing phone is not added to WC order.
 
-= 2019.05.27 		- version 0.8.1 =
+= 2019.05.27 	- version 0.8.1 =
 * Fix           - Don't trigger numeric Date of birth check in checkout for DE.
 
-= 2019.05.27 		- version 0.8.0 =
+= 2019.05.27 	- version 0.8.0 =
 * Feature       - Add support for invoice payments for German customers.
 
-= 2019.03.05 		- version 0.7.0 =
+= 2019.03.05 	- version 0.7.0 =
 * Feature       - Improved handling of refunds (allow order line refunds).
 * Fix           - Updated/corrected Norwegian translation.
 
-= 2019.01.30 		- version 0.6.7 =
+= 2019.01.30 	- version 0.6.7 =
 * Fix           - Fixed refunds on order with no tax rate.
 * Fix           - Description on refund no longer required.
 * Fix           - Improved error handling of refunds.
 
-= 2018.10.19 		- version 0.6.6 =
+= 2018.10.19 	- version 0.6.6 =
 * Tweak			- Limit first and last name to max 50 characters when sending them to AfterPay.
 * Tweak			- Changed the limit for yourReference to max 19 characters when sending it to AfterPay.
 * Tweak			- Add support for multiple subscriptions.
 * Tweak			- Keep address fields disabled in checkout for SE after get address request (even if checkout page is reloaded).
 
-= 2018.10.02 		- version 0.6.5 =
+= 2018.10.02 	- version 0.6.5 =
 * Tweak			- Added filter afterpay_failed_capture_status.
 * Tweak			- Send free shipping  info to AfterPay as well (previously only shipping with a price where sent).
 * Fix			- Tax rate fix if multiple shipping methods exist in order.
 
-= 2018.09.27 		- version 0.6.4 =
+= 2018.09.27 	- version 0.6.4 =
 * Fix			- Limit yourReference to 20 characters (sent to AfterPy for B2B purchases in order capture request).
 * Fix			- PHP notice fix.
 
-= 2018.09.12 		- version 0.6.3 =
+= 2018.09.12 	- version 0.6.3 =
 * Tweak			- Improved messaging when entered personal number is in wrong format.
 * Tweak			- Display part payment example for all countries (previously only displayed for Norway).
 * Tweak			- Updated default Norwegian account payyment method description.
@@ -100,18 +106,18 @@ If you get stuck, you can send a support ticket to support@krokedil.se. You can 
 * Fix			- Make sure TotalNetAmount is sent with 2 decimals.
 * Fix			- Add order note that order hasn't been cancelled in AfterPays system when trying to cancel order after it already being captured.
 
-= 2018.06.12 		- version 0.6.2 =
+= 2018.06.12 	- version 0.6.2 =
 * Tweak			- Add error message as order note + revert status to Processing if AfterPay capture fails.
 * Tweak			- Changed url to Swedish afterpay terms URL.
 * Tweak			- Added link to AfterPay privacy policy next to get address field (for Sweden).
 * Fix			- Fixed PHP warning that caused refunds to not work in some environments.
 
 
-= 2018.05.09 		- version 0.6.1 =
+= 2018.05.09 	- version 0.6.1 =
 * Tweak			- Improved messaging to customer in checkout when purchase (Authorize request) is denied by AfterPay.
 * Tweak			- Display get address form even if AfterPay isn't the selected payment gateway.
 
-= 2018.04.29 		- version 0.6.0 =
+= 2018.04.29 	- version 0.6.0 =
 * Feature       - Add support for recurring payments (for invoice) via WooCommerce Subscriptions.
 * Tweak         - Store AfterPay customer number in WooCommerce order.
 * Tweak         - Added filters afterpay_authorize_order & afterpay_authorize_subscription_renewal_order.
@@ -120,14 +126,14 @@ If you get stuck, you can send a support ticket to support@krokedil.se. You can 
 * Fix           - Send correct params in authorize and capture request for B2B purchases.
 * Fix           - Sync afterpay-pre-check-mobile-number field with billing phone field.
 
-= 2018.04.04 		- version 0.5.1 =
+= 2018.04.04 	- version 0.5.1 =
 * Fix           - Send correct shipping vat to AfterPay even for v2.6.x.
 
-= 2018.03.23 		- version 0.5.0 =
+= 2018.03.23 	- version 0.5.0 =
 * Tweak         - Compatible with WC 2.6.
 * Fix           - Fix so products with 0 amount price & 0% vat can be included in order data sent to AfterPay.
 
-= 2018.03.12 		- version 0.4.0 =
+= 2018.03.12 	- version 0.4.0 =
 * Feature		- Added Account payments.
 * Feature		- Added Part payment Norway.
 * Feature		- Add support for partial refunds (if order only contain one tax rate).
@@ -142,23 +148,23 @@ If you get stuck, you can send a support ticket to support@krokedil.se. You can 
 * Tweak			- Don’t change address data when switching payment method.
 * Tweak			- Update WC order with address information received from AfterPay.
 
-= 2017.11.24 		- version 0.3.2 =
+= 2017.11.24 	- version 0.3.2 =
 * Fix			- Remove - from personal/organization number sent to AfterPay.
 
-= 2017.11.19 		- version 0.3.1 =
+= 2017.11.19 	- version 0.3.1 =
 * Fix			- Don’t display payment method if it isn’t enabled in settings.
 * Fix			- Don’t display part payment if only selling to companies.
 * Tweak			- Hide part payment if customer type company is selected.
 
-= 2017.11.17 			- version 0.3 =
+= 2017.11.17 	- version 0.3 =
 * WordPress.org release
 
-= 2017.11.09 		- version 0.2.1 =
+= 2017.11.09 	- version 0.2.1 =
 * Fix			- Get address feature is not available for companies.
 * Tweak			- Improved handling of returned address data.
 
-= 2017.11.08 		- version 0.2.0 =
+= 2017.11.08 	- version 0.2.0 =
 * Tweak			- Changed textdomain name.
 
-= 2017.08.24 			- version 0.1 =
+= 2017.08.24 	- version 0.1 =
 * Initial release


### PR DESCRIPTION
* Feature - Adds support for invoice payments for Danish customers.
* Tweak - Adds totalNetAmount & order lines to capture payment request.
* Tweak - Adds netUnitPrice & vatAmount to refund payment requests.
* Fix - WC deprecated notices & PHP notices fix.
* Fix - Do not overwrite the customer address in Woo order if company address isn't returned at all from AfterPay.